### PR TITLE
Add ability to truncate {LOGIN} & {EXTERNAL_ACCOUNT} variables in Scheme

### DIFF
--- a/classes/class.ilMatrixChatConfigGUI.php
+++ b/classes/class.ilMatrixChatConfigGUI.php
@@ -138,6 +138,8 @@ class ilMatrixChatConfigGUI extends ilPluginConfigGUI
         $this->plugin->getPluginConfig()
             ->setMatrixServerUrl(rtrim($form->getInput("matrixServerUrl"), "/"))
             ->setSharedSecret($sharedSecretValue)
+            ->setTruncateLoginVariableLength((int) $form->getInput("truncateLoginVariableLength"))
+            ->setTruncateExternalAccountVariableLength((int) $form->getInput("truncateExternalAccountVariableLength"))
             ->setExternalUserScheme($form->getInput("externalUserScheme"))
             ->setExternalUserOptions($form->getInput("externalUserOptions"))
             ->setLocalUserScheme($form->getInput("localUserScheme"))

--- a/classes/class.ilMatrixChatPlugin.php
+++ b/classes/class.ilMatrixChatPlugin.php
@@ -19,7 +19,6 @@ use ILIAS\DI\Container;
 use ILIAS\Plugin\Libraries\ControllerHandler\UiUtils;
 use ILIAS\Plugin\MatrixChat\Api\MatrixApi;
 use ILIAS\Plugin\MatrixChat\Job\ProcessQueuedInvitesJob;
-use ILIAS\Plugin\MatrixChat\Model\CourseSettings;
 use ILIAS\Plugin\MatrixChat\Model\MatrixRoom;
 use ILIAS\Plugin\MatrixChat\Model\MatrixUser;
 use ILIAS\Plugin\MatrixChat\Model\PluginConfig;
@@ -115,8 +114,16 @@ class ilMatrixChatPlugin extends ilUserInterfaceHookPlugin implements ilCronJobP
     {
         return [
             "CLIENT_ID" => CLIENT_ID,
-            "LOGIN" => $this->user->getLogin(),
-            "EXTERNAL_ACCOUNT" => $this->user->getExternalAccount()
+            "LOGIN" => mb_substr(
+                $this->user->getLogin(),
+                0,
+                -$this->getPluginConfig()->getTruncateLoginVariableLength()
+            ),
+            "EXTERNAL_ACCOUNT" => mb_substr(
+                $this->user->getExternalAccount(),
+                0,
+                -$this->getPluginConfig()->getTruncateExternalAccountVariableLength()
+            )
         ];
     }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -14,6 +14,7 @@ config.section.adminAuthentication.valid#:#<span class='sectionTitleWithStatus'>
 config.section.adminAuthentication.invalid#:#<span class='sectionTitleWithStatus'>Admin-Authentifizierung <span class='alert alert-danger sectionStatus'>%s</span></span>
 config.section.restApiAuthentication.valid#:#<span class='sectionTitleWithStatus'>Rest-API Authentifizierung <span class='alert alert-success sectionStatus'>%s</span></span>
 config.section.restApiAuthentication.invalid#:#<span class='sectionTitleWithStatus'>Rest-API Authentifizierung <span class='alert alert-danger sectionStatus'>%s</span></span>
+config.section.user.scheme#:#Schema
 config.section.user.external#:#Extern authentifizierte ILIAS-Benutzer
 config.section.user.local#:#Lokale ILIAS-Benutzer
 config.section.room#:#Raum
@@ -22,6 +23,8 @@ config.section.general#:#Allgemeine Einstellungen
 config.usernameScheme.external#:#Schema zum Verbinden von ILIAS-Benutzern mit externem ILIAS-Account
 config.usernameScheme.local#:#Schema zum Verbinden von ILIAS-Usern mit lokalem ILIAS-Account
 config.usernameScheme.info#:#Dieses Schema wird verwendet, um den Matrix-Benutzernamen zu erzeugen,<br>wenn extern authentifizierte ILIAS-Benutzer einem Matrix-Chat beitreten wollen, aber bisher keinen Benutzer haben. <br><br>Das Schema darf nur die folgenden Zeichen enthalten %s.<br>Großbuchstaben werden in Kleinbuchstaben umgewandelt!<br><br>Unterstützte Variablen: <br>%s
+
+config.usernameScheme.truncate.variable#:#Anzahl Zeichen von <span style="color: blue">%s</span> Variable abschneiden
 
 config.room.prefix#:#Raumpräfix
 config.room.prefix.info#:#Dieses Schema wird verwendet, um den Präfix für die Benennung des Matrix-Chatraumes zu erzeugen. <br>Dieser Präfix wird vor den namen des Kurses/der Gruppe gesetzt zu dem dieser Chatraum zugewiesen bzw. durch den dieser erstellt wurde. <br><br>Unterstützte Variablen: <br>%s

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -14,6 +14,7 @@ config.section.adminAuthentication.valid#:#<span class='sectionTitleWithStatus'>
 config.section.adminAuthentication.invalid#:#<span class='sectionTitleWithStatus'>Admin-Authentication <span class='alert alert-danger sectionStatus'>%s</span></span>
 config.section.restApiAuthentication.valid#:#<span class='sectionTitleWithStatus'>Rest-API Authentication <span class='alert alert-success sectionStatus'>%s</span></span>
 config.section.restApiAuthentication.invalid#:#<span class='sectionTitleWithStatus'>Rest-API Authentication <span class='alert alert-danger sectionStatus'>%s</span></span>
+config.section.user.scheme#:#Scheme
 config.section.user.external#:#Externally Authenticated ILIAS Users
 config.section.user.local#:#Local ILIAS Users
 config.section.room#:#Room
@@ -22,6 +23,8 @@ config.section.general#:#General Settings
 config.usernameScheme.external#:#Scheme for connecting ILIAS users with an external account
 config.usernameScheme.local#:#Scheme for connecting ILIAS users with an local account
 config.usernameScheme.info#:#This scheme is used to create the matrix username,<br>when externally authenticated ILIAS users want to join a Matrix chat but do not have a user yet.<br><br>The scheme may only contain the characters %s.<br>Uppercase letters are converted to lowercase!<br><br>Supported variables: <br>%s
+
+config.usernameScheme.truncate.variable#:#Truncate Number of Characters from <span style="color: blue">%s</span> Variable
 
 config.room.prefix#:#Room Prefix
 config.room.prefix.info#:#This scheme is used to create the prefix for the naming of the Matrix-Chatroom. <br>This prefix is put in front of the name of the course/group this chatroom is assigned to/created by. <br><br>Supported variables: <br>%s

--- a/src/Form/PluginConfigForm.php
+++ b/src/Form/PluginConfigForm.php
@@ -67,6 +67,7 @@ class PluginConfigForm extends ilPropertyFormGUI
         $this->addServerSection($serverReachable);
         $this->addAdminUserSection($serverReachable);
         $this->addRestApiUserSection($serverReachable);
+        $this->addSchemeSection();
         $this->addExternalUserSection($allowedUsernameSchemeCharacters);
         $this->addLocalUserSection($allowedUsernameSchemeCharacters);
         $this->addRoomSection();
@@ -198,6 +199,29 @@ class PluginConfigForm extends ilPropertyFormGUI
         );
         $matrixRestApiUserRemoveRateLimit->setInfo($this->plugin->txt("config.removeRateLimit.info"));
         $this->addItem($matrixRestApiUserRemoveRateLimit);
+    }
+
+    private function addSchemeSection(): void
+    {
+        $section = new ilFormSectionHeaderGUI();
+        $section->setTitle($this->plugin->txt("config.section.user.scheme"));
+        $this->addItem($section);
+
+        $truncateLoginVariableLength = new ilNumberInputGUI(
+            sprintf($this->plugin->txt("config.usernameScheme.truncate.variable"), "LOGIN"),
+            "truncateLoginVariableLength"
+        );
+        $truncateLoginVariableLength->setRequired(true);
+        $truncateLoginVariableLength->setMinValue(0);
+        $this->addItem($truncateLoginVariableLength);
+
+        $truncateExternalAccountVariableLength = new ilNumberInputGUI(
+            sprintf($this->plugin->txt("config.usernameScheme.truncate.variable"), "EXTERNAL_ACCOUNT"),
+            "truncateExternalAccountVariableLength"
+        );
+        $truncateExternalAccountVariableLength->setRequired(true);
+        $truncateExternalAccountVariableLength->setMinValue(0);
+        $this->addItem($truncateExternalAccountVariableLength);
     }
 
     protected function addExternalUserSection(array $allowedCharacters): void

--- a/src/Model/PluginConfig.php
+++ b/src/Model/PluginConfig.php
@@ -41,6 +41,8 @@ class PluginConfig extends SettingsConfig
     private int $adminPowerLevel = 100;
     private int $tutorPowerLevel = 50;
     private int $memberPowerLevel = 0;
+    private int $truncateLoginVariableLength = 0;
+    private int $truncateExternalAccountVariableLength = 0;
 
     public function getMatrixServerUrl(): string
     {
@@ -83,6 +85,28 @@ class PluginConfig extends SettingsConfig
     public function setSharedSecret(string $sharedSecret): PluginConfig
     {
         $this->sharedSecret = $sharedSecret;
+        return $this;
+    }
+
+    public function getTruncateLoginVariableLength(): int
+    {
+        return $this->truncateLoginVariableLength;
+    }
+
+    public function setTruncateLoginVariableLength(int $truncateLoginVariableLength): PluginConfig
+    {
+        $this->truncateLoginVariableLength = $truncateLoginVariableLength;
+        return $this;
+    }
+
+    public function getTruncateExternalAccountVariableLength(): int
+    {
+        return $this->truncateExternalAccountVariableLength;
+    }
+
+    public function setTruncateExternalAccountVariableLength(int $truncateExternalAccountVariableLength): PluginConfig
+    {
+        $this->truncateExternalAccountVariableLength = $truncateExternalAccountVariableLength;
         return $this;
     }
 


### PR DESCRIPTION
Proper implemention of https://github.com/DatabayAG/MatrixChat/pull/1